### PR TITLE
Store ContentId against the LinkedResource

### DIFF
--- a/src/Essential.Templating.Razor.Email/Helpers/ResourceTemplateHelperExtensions.cs
+++ b/src/Essential.Templating.Razor.Email/Helpers/ResourceTemplateHelperExtensions.cs
@@ -25,7 +25,8 @@ namespace Essential.Templating.Razor.Email.Helpers
             }
             var linkedResource = new LinkedResource(resource, mediaType)
             {
-                TransferEncoding = transferEncoding
+                TransferEncoding = transferEncoding,
+                ContentId = contentId
             };
             helper.AddLinkedResource(linkedResource);
             var renderedResult = new RawString(string.Format("cid:{0}", contentId));


### PR DESCRIPTION
ContentId is not being set for the LinkedResource so once rendered, the cid value in the HTML content can't be found as it isn't named.
